### PR TITLE
Added two files to .gitignore that are created during a build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,10 @@ build/
 fms/
 tmp/
 
+# Files created during a build
+MOM6_ALE/build_ale/Makefile
+fms_build/Makefile
+
 # Additional
 .*
 path_names*


### PR DESCRIPTION
MOM6_ALE/build_ale/Makefile and fms_build/Makefile are left behind after a build and show up as untracked files. This makes it appear that MIDAS (as a submodule) has been modified when it has not.

Should fix issue mjharriso/MIDAS#5.
