### PR TITLE
Fixes git checkout in wrong directory

### DIFF
--- a/Makefile_GFDL
+++ b/Makefile_GFDL
@@ -19,7 +19,7 @@ MIDAS:	fms_build/libfms.a MOM6_ALE/build_ale/libale.a
 
 fms_build/libfms.a:
 	(cd fms;tar xvf fms_env.tar)
-	(cd fms;git clone https://github.com/NOAA-GFDL/FMS.git shared;git checkout 34097d0)
+	(cd fms;git clone https://github.com/NOAA-GFDL/FMS.git shared;cd shared;git checkout 34097d0)
 	(cd fms_build;./build_fms.csh)
 
 MOM6_ALE/build_ale/libale.a:

--- a/Makefile_gfortran
+++ b/Makefile_gfortran
@@ -11,7 +11,7 @@ MIDAS: fms_build/libfms.a MOM6_ALE/build_ale/libale.a
 
 fms_build/libfms.a:
 	(cd fms;tar xvf fms_env.tar)
-	(cd fms;git clone https://github.com/NOAA-GFDL/FMS.git shared; git checkout 34097d0)
+	(cd fms;git clone https://github.com/NOAA-GFDL/FMS.git shared;cd shared;git checkout 34097d0)
 	(cd fms_build;cp build_fms.csh tmp;\
 	  sed -e 's/#set platform = linux/set platform = linux/' < tmp > tmp2;\
 	  sed -e 's/set platform = gfdl_hpcs/#set platform = gfdl_hpcs/' < tmp2 > build_fms.csh;\


### PR DESCRIPTION
- Commit 3ccbec6c9ee9 tries to checkout a specific commit of FMS shared code.
  The clone is made into a directory called "shared" but the subsequent
  checkout is made in the parent directory and thus fails.